### PR TITLE
Fix decoding of planar tiled multiband images

### DIFF
--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -674,3 +674,15 @@ fn bytes_gray_f32() {
         byte_order_u32,
     );
 }
+
+#[test]
+fn test_multiband_f64() {
+    test_image_sum_f64(
+        "large-f64-multiband.tif",
+        ColorType::Multiband {
+            bit_depth: 64,
+            num_samples: 3,
+        },
+        -23436807936.84004,
+    );
+}


### PR DESCRIPTION
## Summary
- fix planar tiled decoding by normalizing tile index per band
- add regression test for `large-f64-multiband.tif`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b201f9cd58832ba7ed768bf96b9da1